### PR TITLE
Add LOG_LEVEL_NOFN macros as a workaround for cases when __FUNCTION__…

### DIFF
--- a/quill/include/quill/detail/LogMacros.h
+++ b/quill/include/quill/detail/LogMacros.h
@@ -38,6 +38,25 @@ constexpr void check_format(const S& format_str, Args&&...)
 }
 
 // Main Log Macros
+
+#if defined(QUILL_NOFN_MACROS)
+// clang-format off
+#define QUILL_LOGGER_CALL_NOFN(likelyhood, logger, log_statement_level, fmt, ...) do {                                                                    \
+    check_format(FMT_STRING(fmt), ##__VA_ARGS__);                                                                                                    \
+                                                                                                                                                     \
+    struct {                                                                                                                                         \
+      constexpr quill::detail::LogRecordMetadata operator()() const noexcept {                                                                       \
+        return quill::detail::LogRecordMetadata{QUILL_STRINGIFY(__LINE__), __FILE__, "n/a", fmt, log_statement_level}; }                     \
+      } anonymous_log_record_info;                                                                                                                   \
+                                                                                                                                                     \
+    if (likelyhood(logger->should_log<log_statement_level>()))                                                                                       \
+    {                                                                                                                                                \
+      logger->log<decltype(anonymous_log_record_info)>(__VA_ARGS__);                                                                                 \
+    }                                                                                                                                                \
+  } while (0)
+// clang-format on
+#endif
+
 // clang-format off
 #define QUILL_LOGGER_CALL(likelyhood, logger, log_statement_level, fmt, ...) do {                                                                    \
     check_format(FMT_STRING(fmt), ##__VA_ARGS__);                                                                                                    \
@@ -58,55 +77,127 @@ constexpr void check_format(const S& format_str, Args&&...)
 #if QUILL_ACTIVE_LOG_LEVEL <= QUILL_LOG_LEVEL_TRACE_L3
   #define LOG_TRACE_L3(logger, fmt, ...)                                                           \
     QUILL_LOGGER_CALL(QUILL_UNLIKELY, logger, quill::LogLevel::TraceL3, fmt, ##__VA_ARGS__)
+
+  #if defined(QUILL_NOFN_MACROS)
+    #define LOG_TRACE_L3_NOFN(logger, fmt, ...)                                                    \
+      QUILL_LOGGER_CALL_NOFN(QUILL_UNLIKELY, logger, quill::LogLevel::TraceL3, fmt, ##__VA_ARGS__)
+  #endif
 #else
   #define LOG_TRACE_L3(logger, fmt, ...) (void)0
+
+  #if defined(QUILL_NOFN_MACROS)
+    #define LOG_TRACE_L3_NOFN(logger, fmt, ...) (void)0
+  #endif
 #endif
 
 #if QUILL_ACTIVE_LOG_LEVEL <= QUILL_LOG_LEVEL_TRACE_L2
   #define LOG_TRACE_L2(logger, fmt, ...)                                                           \
     QUILL_LOGGER_CALL(QUILL_UNLIKELY, logger, quill::LogLevel::TraceL2, fmt, ##__VA_ARGS__)
+
+  #if defined(QUILL_NOFN_MACROS)
+    #define LOG_TRACE_L2_NOFN(logger, fmt, ...)                                                    \
+      QUILL_LOGGER_CALL_NOFN(QUILL_UNLIKELY, logger, quill::LogLevel::TraceL2, fmt, ##__VA_ARGS__)
+  #endif
 #else
   #define LOG_TRACE_L2(logger, fmt, ...) (void)0
+
+  #if defined(QUILL_NOFN_MACROS)
+    #define LOG_TRACE_L2_NOFN(logger, fmt, ...) (void)0
+  #endif
 #endif
 
 #if QUILL_ACTIVE_LOG_LEVEL <= QUILL_LOG_LEVEL_TRACE_L1
   #define LOG_TRACE_L1(logger, fmt, ...)                                                           \
     QUILL_LOGGER_CALL(QUILL_UNLIKELY, logger, quill::LogLevel::TraceL1, fmt, ##__VA_ARGS__)
+
+  #if defined(QUILL_NOFN_MACROS)
+    #define LOG_TRACE_L1_NOFN(logger, fmt, ...)                                                    \
+      QUILL_LOGGER_CALL_NOFN(QUILL_UNLIKELY, logger, quill::LogLevel::TraceL1, fmt, ##__VA_ARGS__)
+  #endif
 #else
   #define LOG_TRACE_L1(logger, fmt, ...) (void)0
+
+  #if defined(QUILL_NOFN_MACROS)
+    #define LOG_TRACE_L1_NOFN(logger, fmt, ...) (void)0
+  #endif
 #endif
 
 #if QUILL_ACTIVE_LOG_LEVEL <= QUILL_LOG_LEVEL_DEBUG
   #define LOG_DEBUG(logger, fmt, ...)                                                              \
     QUILL_LOGGER_CALL(QUILL_UNLIKELY, logger, quill::LogLevel::Debug, fmt, ##__VA_ARGS__)
+
+  #if defined(QUILL_NOFN_MACROS)
+    #define LOG_DEBUG_NOFN(logger, fmt, ...)                                                       \
+      QUILL_LOGGER_CALL_NOFN(QUILL_UNLIKELY, logger, quill::LogLevel::Debug, fmt, ##__VA_ARGS__)
+  #endif
 #else
   #define LOG_DEBUG(logger, fmt, ...) (void)0
+
+  #if defined(QUILL_NOFN_MACROS)
+    #define LOG_DEBUG_NOFN(logger, fmt, ...) (void)0
+  #endif
 #endif
 
 #if QUILL_ACTIVE_LOG_LEVEL <= QUILL_LOG_LEVEL_INFO
   #define LOG_INFO(logger, fmt, ...)                                                               \
     QUILL_LOGGER_CALL(QUILL_LIKELY, logger, quill::LogLevel::Info, fmt, ##__VA_ARGS__)
+
+  #if defined(QUILL_NOFN_MACROS)
+    #define LOG_INFO_NOFN(logger, fmt, ...)                                                        \
+      QUILL_LOGGER_CALL_NOFN(QUILL_LIKELY, logger, quill::LogLevel::Info, fmt, ##__VA_ARGS__)
+  #endif
 #else
   #define LOG_INFO(logger, fmt, ...) (void)0
+
+  #if defined(QUILL_NOFN_MACROS)
+    #define LOG_INFO_NOFN(logger, fmt, ...) (void)0
+  #endif
 #endif
 
 #if QUILL_ACTIVE_LOG_LEVEL <= QUILL_LOG_LEVEL_WARNING
   #define LOG_WARNING(logger, fmt, ...)                                                            \
     QUILL_LOGGER_CALL(QUILL_LIKELY, logger, quill::LogLevel::Warning, fmt, ##__VA_ARGS__)
+
+  #if defined(QUILL_NOFN_MACROS)
+    #define LOG_WARNING_NOFN(logger, fmt, ...)                                                     \
+      QUILL_LOGGER_CALL_NOFN(QUILL_LIKELY, logger, quill::LogLevel::Warning, fmt, ##__VA_ARGS__)
+  #endif
 #else
   #define LOG_WARNING(logger, fmt, ...) (void)0
+
+  #if defined(QUILL_NOFN_MACROS)
+    #define LOG_WARNING_NOFN(logger, fmt, ...) (void)0
+  #endif
 #endif
 
 #if QUILL_ACTIVE_LOG_LEVEL <= QUILL_LOG_LEVEL_ERROR
   #define LOG_ERROR(logger, fmt, ...)                                                              \
     QUILL_LOGGER_CALL(QUILL_LIKELY, logger, quill::LogLevel::Error, fmt, ##__VA_ARGS__)
+
+  #if defined(QUILL_NOFN_MACROS)
+    #define LOG_ERROR_NOFN(logger, fmt, ...)                                                       \
+      QUILL_LOGGER_CALL_NOFN(QUILL_LIKELY, logger, quill::LogLevel::Error, fmt, ##__VA_ARGS__)
+  #endif
 #else
   #define LOG_ERROR(logger, fmt, ...) (void)0
+
+  #if defined(QUILL_NOFN_MACROS)
+    #define LOG_ERROR_NOFN(logger, fmt, ...) (void)0
+  #endif
 #endif
 
 #if QUILL_ACTIVE_LOG_LEVEL <= QUILL_LOG_LEVEL_CRITICAL
   #define LOG_CRITICAL(logger, fmt, ...)                                                           \
     QUILL_LOGGER_CALL(QUILL_LIKELY, logger, quill::LogLevel::Critical, fmt, ##__VA_ARGS__)
+
+  #if defined(QUILL_NOFN_MACROS)
+    #define LOG_CRITICAL_NOFN(logger, fmt, ...)                                                    \
+      QUILL_LOGGER_CALL_NOFN(QUILL_LIKELY, logger, quill::LogLevel::Critical, fmt, ##__VA_ARGS__)
+  #endif
 #else
   #define LOG_CRITICAL(logger, fmt, ...) (void)0
+
+  #if defined(QUILL_NOFN_MACROS)
+    #define LOG_CRITICAL_NOFN(logger, fmt, ...) (void)0
+  #endif
 #endif


### PR DESCRIPTION
… is not used as a constant expression in versions of GCC prior to 9.0.

resolves #28